### PR TITLE
Sync exclude flag

### DIFF
--- a/boostedblob/cli.py
+++ b/boostedblob/cli.py
@@ -614,7 +614,7 @@ eval "$(bbb complete init zsh)"
     subparser.add_argument(
         "-x",
         "--exclude",
-        help="Do not copy or delete files that don't match this Python regular expression",
+        help="Only copy or delete files that don't match this Python regular expression",
     )
     subparser.add_argument("-q", "--quiet", action="store_true")
     subparser.add_argument("--concurrency", **concurrency_kwargs)

--- a/boostedblob/cli.py
+++ b/boostedblob/cli.py
@@ -438,7 +438,11 @@ $ bbb share gs://bucket/frogs.txt
 bbb will change the destination so that it better mirrors the source.
 Specifically, bbb will copy over or replace files in the destination that are
 missing or have changed in the source. If --delete is specified, bbb will delete
-files in the destination that are not present in the source.
+files in the destination that are not present in the source. If --exclude (-x)
+is specified, bbb will not copy or delete any files whose relative path matches
+the given regex at any position (i.e. using the semantics of Python's
+re.search). Consider using regex anchors (^$) to ensure you're excluding exactly
+what you intend.
 
 Example:
 $ bbb sync gs://tmp/boostedblob boostedblob
@@ -446,6 +450,9 @@ $ bbb sync gs://tmp/boostedblob boostedblob
 Using --delete and re-syncing will delete spurious_file.txt:
 $ touch boostedblob/spurious_file.txt
 $ bbb sync --delete gs://tmp/boostedblob boostedblob
+
+Sync all files except those with .txt extension
+$ bbb sync gs://tmp/boostedblob boostedblob -x '\\.txt$'
 """
     complete_desc = """\
 To enable tab completion for bash, add the following to your bashrc:
@@ -610,7 +617,10 @@ eval "$(bbb complete init zsh)"
     subparser.add_argument(
         "-x",
         "--exclude",
-        help="Only copy or delete files that don't match this Python regular expression",
+        help=(
+            "Only copy or delete files whose relative path don't match this Python regular "
+            "expression at any position"
+        ),
     )
     subparser.add_argument("-q", "--quiet", action="store_true")
     subparser.add_argument("--concurrency", **concurrency_kwargs)

--- a/boostedblob/cli.py
+++ b/boostedblob/cli.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import functools
 import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -224,21 +223,12 @@ async def sync(
 ) -> None:
     src_obj = bbb.BasePath.from_str(src)
     dst_obj = bbb.BasePath.from_str(dst)
-    try:
-        exclude_pattern = re.compile(exclude) if exclude is not None else None
-    except re.error as e:
-        raise ValueError(
-            f"Failed to compile exclude pattern {repr(exclude)}: {e}\n"
-            "Hint: exclude patterns should be Python regular expressions, not globs."
-        )
 
     src_is_dirlike = src_obj.is_directory_like() or await bbb.isdir(src_obj)
     if not src_is_dirlike:
         raise ValueError(f"{src_obj} is not a directory")
     async with bbb.BoostExecutor(concurrency) as executor:
-        async for p in bbb.sync(
-            src_obj, dst_obj, executor, delete=delete, exclude_pattern=exclude_pattern
-        ):
+        async for p in bbb.sync(src_obj, dst_obj, executor, delete=delete, exclude=exclude):
             if not quiet:
                 print(p)
 

--- a/boostedblob/cli.py
+++ b/boostedblob/cli.py
@@ -224,7 +224,13 @@ async def sync(
 ) -> None:
     src_obj = bbb.BasePath.from_str(src)
     dst_obj = bbb.BasePath.from_str(dst)
-    exclude_pattern = re.compile(exclude) if exclude is not None else None
+    try:
+        exclude_pattern = re.compile(exclude) if exclude is not None else None
+    except re.error as e:
+        raise ValueError(
+            f"Failed to compile exclude pattern {repr(exclude)}: {e}\n"
+            "Hint: exclude patterns should be Python regular expressions, not globs."
+        )
 
     src_is_dirlike = src_obj.is_directory_like() or await bbb.isdir(src_obj)
     if not src_is_dirlike:

--- a/boostedblob/syncing.py
+++ b/boostedblob/syncing.py
@@ -54,7 +54,7 @@ async def sync_action_iterator(
             # Note that if you create marker files to mark directories, scantree will return
             # those. Filter by is_file to avoid syncing these files that represent directories.
             files = [(p.path.relative_to(tree), p) async for p in scantree(tree) if p.is_file]
-            return [p for p in files if exclude_pattern is None or not exclude_pattern.match(p[0])]
+            return [p for p in files if exclude_pattern is None or not exclude_pattern.search(p[0])]
         except FileNotFoundError:
             return []
 

--- a/boostedblob/syncing.py
+++ b/boostedblob/syncing.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import sys
 from dataclasses import dataclass
 from typing import AsyncIterator, Iterator, List, Optional, Tuple, Union
@@ -26,7 +27,9 @@ class DeleteAction(Action):
     pass
 
 
-async def sync_action_iterator(src: BasePath, dst: BasePath) -> Iterator[Action]:
+async def sync_action_iterator(
+    src: BasePath, dst: BasePath, exclude_pattern: Optional[re.Pattern] = None
+) -> Iterator[Action]:
     """Yields the actions to take to sync the tree rooted at ``src`` to ``dst``.
 
     :param src: The root of the tree to copy from.
@@ -42,7 +45,8 @@ async def sync_action_iterator(src: BasePath, dst: BasePath) -> Iterator[Action]
         try:
             # Note that if you create marker files to mark directories, scantree will return
             # those. Filter by is_file to avoid syncing these files that represent directories.
-            return [(p.path.relative_to(tree), p) async for p in scantree(tree) if p.is_file]
+            files = [(p.path.relative_to(tree), p) async for p in scantree(tree) if p.is_file]
+            return [p for p in files if exclude_pattern is None or not exclude_pattern.match(p[0])]
         except FileNotFoundError:
             return []
 
@@ -89,6 +93,7 @@ async def sync(
     dst: Union[str, BasePath],
     executor: BoostExecutor,
     delete: bool = False,
+    exclude_pattern: Optional[re.Pattern] = None,
 ) -> AsyncIterator[BasePath]:
     """Syncs the tree rooted at ``src`` to ``dst``.
 
@@ -135,7 +140,10 @@ async def sync(
                 return await delete_wrapper(action.relpath)
         return None
 
-    actions = executor.map_unordered(action_wrapper, await sync_action_iterator(src_obj, dst_obj))
+    actions = executor.map_unordered(
+        action_wrapper,
+        await sync_action_iterator(src_obj, dst_obj, exclude_pattern=exclude_pattern),
+    )
     async for path in actions:
         if path is not None:
             yield path

--- a/tests/test_syncing.py
+++ b/tests/test_syncing.py
@@ -61,7 +61,7 @@ async def test_sync(any_dir, other_any_dir):
             bbb.syncing.DeleteAction("f2"),
         ]
         actions = sorted(
-            await bbb.syncing.sync_action_iterator(any_dir, other_any_dir, exclude="f"),
+            await bbb.syncing.sync_action_iterator(any_dir, other_any_dir, exclude="^f"),
             key=lambda x: x.relpath,
         )
         assert actions == [

--- a/tests/test_syncing.py
+++ b/tests/test_syncing.py
@@ -52,6 +52,22 @@ async def test_sync(any_dir, other_any_dir):
             bbb.syncing.CopyAction("f1", 8),
             bbb.syncing.DeleteAction("f2"),
         ]
+        actions = sorted(
+            await bbb.syncing.sync_action_iterator(any_dir, other_any_dir, exclude="delta"),
+            key=lambda x: x.relpath,
+        )
+        assert actions == [
+            bbb.syncing.CopyAction("f1", 8),
+            bbb.syncing.DeleteAction("f2"),
+        ]
+        actions = sorted(
+            await bbb.syncing.sync_action_iterator(any_dir, other_any_dir, exclude="f"),
+            key=lambda x: x.relpath,
+        )
+        assert actions == [
+            bbb.syncing.CopyAction("delta/f9", 13),
+        ]
+
         await bbb.boost.consume(bbb.sync(any_dir, other_any_dir, e, delete=True))
         assert await _listtree(any_dir, any_dir) == await _listtree(other_any_dir, other_any_dir)
 


### PR DESCRIPTION
Adds an `-x` / `--exclude` flag to the `sync` command to exclude paths that match a regex.