### PR TITLE
Adds optional azure-identity support

### DIFF
--- a/boostedblob/azure_auth.py
+++ b/boostedblob/azure_auth.py
@@ -139,6 +139,7 @@ def load_stored_subscription_ids() -> List[str]:
     subscriptions.sort(key=lambda x: x["isDefault"], reverse=True)
     return [sub["id"] for sub in subscriptions]
 
+
 async def get_access_token(cache_key: Tuple[str, Optional[str]]) -> Tuple[Any, float]:
     account, container = cache_key
 
@@ -149,7 +150,7 @@ async def get_access_token(cache_key: Tuple[str, Optional[str]]) -> Tuple[Any, f
     # This enables the use of Managed Identity, Workload Identity, and other auth methods not implemented here
     if creds["_azure_auth"] == "azure-identity":
         try:
-            from azure.identity.aio import DefaultAzureCredential # type: ignore
+            from azure.identity.aio import DefaultAzureCredential  # type: ignore
         except ImportError:
             raise RuntimeError(
                 "When setting AZURE_USE_IDENTITY=1, you must also install the azure-identity package"

--- a/boostedblob/azure_auth.py
+++ b/boostedblob/azure_auth.py
@@ -139,7 +139,6 @@ def load_stored_subscription_ids() -> List[str]:
     subscriptions.sort(key=lambda x: x["isDefault"], reverse=True)
     return [sub["id"] for sub in subscriptions]
 
-
 async def get_access_token(cache_key: Tuple[str, Optional[str]]) -> Tuple[Any, float]:
     account, container = cache_key
 
@@ -150,7 +149,7 @@ async def get_access_token(cache_key: Tuple[str, Optional[str]]) -> Tuple[Any, f
     # This enables the use of Managed Identity, Workload Identity, and other auth methods not implemented here
     if creds["_azure_auth"] == "azure-identity":
         try:
-            from azure.identity.aio import DefaultAzureCredential
+            from azure.identity.aio import DefaultAzureCredential # type: ignore
         except ImportError:
             raise RuntimeError(
                 "When setting AZURE_USE_IDENTITY=1, you must also install the azure-identity package"

--- a/boostedblob/azure_auth.py
+++ b/boostedblob/azure_auth.py
@@ -25,6 +25,10 @@ SHARED_KEY = "shared_key"
 
 
 def load_credentials() -> Dict[str, Any]:
+    # When USE_AZURE_IDENTITY=1, boostedblob will use the azure-identity package to retrieve AAD access tokens
+    if os.getenv("USE_AZURE_IDENTITY", "0") == "1":
+        return {"_azure_auth": "azure-identity"}
+
     # AZURE_STORAGE_KEY seems to be the environment variable mentioned by the az cli
     # AZURE_STORAGE_ACCOUNT_KEY is mentioned elsewhere on the internet
     for varname in ["AZURE_STORAGE_KEY", "AZURE_STORAGE_ACCOUNT_KEY"]:
@@ -141,6 +145,17 @@ async def get_access_token(cache_key: Tuple[str, Optional[str]]) -> Tuple[Any, f
 
     now = time.time()
     creds = load_credentials()
+
+    # If opted into using azure-identity, use DefaultAzureCredential to get a token
+    # This enables the use of Managed Identity, Workload Identity, and other auth methods not implemented here
+    if creds["_azure_auth"] == "azure-identity":
+        from azure.identity import DefaultAzureCredential
+
+        cred = DefaultAzureCredential()
+        token = cred.get_token("https://storage.azure.com/.default")
+        auth = (OAUTH_TOKEN, token.token)
+        if await can_access_account(account, container, auth):
+            return (auth, token.expires_on)
 
     if creds["_azure_auth"] == "sakey":
         if "account" in creds:


### PR DESCRIPTION
boostedblob currently uses a custom implementation of auth to Azure Storage. It works with a client secret, but doesn't work in other (recommended) credential-free flows, such as

* Managed Identity - apps talk to the local IMDS/IDENTITY_ENDPOINT for a token associated with a VM/Web App's identity
* Workload Identity - apps exchange an OIDC token (ex: minted by an AKS cluster) for an AAD token associated with a particular User Assigned Identity

This PR adds an **opt-in** feature with no new dependencies. If apps set `AZURE_USE_IDENTITY=1`, boostedblob will bypass the custom implementation here and instead use `DefaultAzureCredential` to retrieve tokens - which has support for the above named flows (and more). Apps will need to bring their own`azure-identity` dependency via `pyproject.toml`, `requirements.txt`, or otherwise