### PR TITLE
add support for msi endpoints

### DIFF
--- a/boostedblob/azure_auth.py
+++ b/boostedblob/azure_auth.py
@@ -328,7 +328,7 @@ def create_access_token_request(
         url = creds["msi_endpoint"]
         data = {"resource": scope}
     else:
-        raise AssertionError
+        raise AssertionError(f"Unknown auth type: {creds['_azure_auth']}")
 
     return Request(
         url=url,


### PR DESCRIPTION
This PR introduces Azure authentication support for MSI_ENDPOINTs (Managed Service Identity) by adding explicit support rather than relying on the AZURE_USE_IDENTITY flag. This approach allows the endpoint to utilize the same token request flow defined for the refresh auth type, which offers a more limited scope.