### PR TITLE
GCS fixes

### DIFF
--- a/boostedblob/copying.py
+++ b/boostedblob/copying.py
@@ -306,7 +306,11 @@ async def _azure_cloud_copyfile(
 
 @cloud_copyfile.register  # type: ignore
 async def _google_cloud_copyfile(
-    src: GooglePath, dst: GooglePath, executor: BoostExecutor, overwrite: bool = False
+    src: GooglePath,
+    dst: GooglePath,
+    executor: BoostExecutor,
+    overwrite: bool = False,
+    size: Optional[int] = None,
 ) -> None:
     assert isinstance(dst, GooglePath)
     if not overwrite:

--- a/boostedblob/write.py
+++ b/boostedblob/write.py
@@ -198,7 +198,7 @@ async def _google_write_stream(
         # invalid chunk size. If we continue to receive chunks, which can happen if the file is
         # being written to concurrently, then we discard these additional chunks.
         if is_finalised:
-            continue
+            break
         should_finalise = len(chunk) % (256 * 1024) != 0
         if should_finalise:
             total_size = str(end)

--- a/boostedblob/write.py
+++ b/boostedblob/write.py
@@ -195,16 +195,12 @@ async def _google_write_stream(
         # chunk. If you upload a chunk with another size you get an HTTP 400 error, unless you tell
         # GCS that it's the last chunk. Since our interface doesn't allow us to know whether or not
         # a given chunk is actually the last chunk, we go ahead and assume that it is if it's an
-        # invalid chunk size. If we receive multiple chunks of invalid chunk size, we throw an
-        # error.
+        # invalid chunk size. If we continue to receive chunks, which can happen if the file is
+        # being written to concurrently, then we discard these additional chunks.
+        if is_finalised:
+            continue
         should_finalise = len(chunk) % (256 * 1024) != 0
         if should_finalise:
-            if is_finalised:
-                raise ValueError(
-                    "The upload was already finalised. A likely cause is the given stream was "
-                    "chunked incorrectly. Uploads to Google Cloud need to be chunked in "
-                    "multiples of 256 KB (except for the last chunk)."
-                )
             total_size = str(end)
             is_finalised = True
 

--- a/boostedblob/write.py
+++ b/boostedblob/write.py
@@ -198,6 +198,16 @@ async def _google_write_stream(
         # invalid chunk size. If we continue to receive chunks, which can happen if the file is
         # being written to concurrently, then we discard these additional chunks.
         if is_finalised:
+            if chunk:
+                import warnings
+
+                warnings.warn(
+                    "The upload was already finalised. A likely cause is a) the file was being "
+                    "written to concurrently, or b) the given stream was chunked incorrectly. "
+                    "Uploads to Google Cloud need to be chunked in multiples of 256 KB "
+                    "(except for the last chunk).",
+                    stacklevel=2,
+                )
             break
         should_finalise = len(chunk) % (256 * 1024) != 0
         if should_finalise:

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -13,7 +13,7 @@ async def test_google_chunking():
     with helpers.tmp_google_dir() as google_dir:
         async with bbb.BoostExecutor(10) as e:
             contents = [b"abc", b"def", b"ghi"]
-            with pytest.raises(ValueError, match="chunked incorrectly"):
+            with pytest.warns(UserWarning, match="chunked incorrectly"):
                 await bbb.write.write_stream(google_dir / "alpha", iter(contents), e)
 
 


### PR DESCRIPTION
Two small fixes for GCS.

The first fixes a bug introduced in https://github.com/hauntsaninja/boostedblob/commit/4594df1a9781e5853ddc11be46dffb009a5c7193 where the type signature of `cloud_copyfile` was changed but the GCS function was not updated, preventing `bbb cptree` between GCS paths from working.

The second fixes an issue where copying a local file to GCS can fail if the local file is being written to concurrently. For example:

```
import subprocess
import threading

from boostedblob.cli import cp


def write_to_local(local_path):
    try:
        subprocess.run(
            f"while true; do echo {{0..1000}}; done > {local_path}",
            shell=True,
            timeout=2,
        )
    except subprocess.TimeoutExpired:
        print("Finished writing.")


def copy_while_writing(local_path, gs_path):
    write_thread = threading.Thread(target=write_to_local, args=(local_path,))
    write_thread.start()
    cp([local_path], gs_path)
    print("Finished copying.")
    write_thread.join()
```

Calling `copy_while_writing` triggers a `ValueError: The upload was already finalised. ...`. Although this PR doesn't fix the underlying issue with GCS chunk sizes, I believe the new behavior is preferable since it is unsurprising (if the file is being appended to concurrently, then the file is copied as it was in some intermediate state, instead of the entire command failing). Maybe there should be a warning though, I'm not sure what your preferences are there.