### PR TITLE
Handle EAI_NODATA in _bad_hostname_check

### DIFF
--- a/boostedblob/request.py
+++ b/boostedblob/request.py
@@ -367,7 +367,7 @@ async def _bad_hostname_check(hostname: str) -> bool:
             # no errors encountered, the hostname exists
             return False
         except OSError as e:
-            if e.errno != socket.EAI_NONAME:
+            if e.errno != socket.EAI_NONAME and e.errno != socket.EAI_NODATA:
                 # we got some sort of other socket error, so it's unclear if the host exists or not
                 return False
 


### PR DESCRIPTION
On Ubuntu 24.04, looking up an unresolveable `<something>.blob.core.windows.net` returns `EAI_NODATA`, not `EAI_NONAME`. The result is that `bbb ls az://<something>` gets stuck in a backoff loop instead of returning a `FileNotFoundError`. 