### PR TITLE
Update path.py: return annotation bool not int

### DIFF
--- a/boostedblob/path.py
+++ b/boostedblob/path.py
@@ -562,7 +562,7 @@ async def exists(path: Union[BasePath, BlobPath, str]) -> int:
 
 
 @exists.register  # type: ignore
-async def _cloud_exists(path: CloudPath) -> int:
+async def _cloud_exists(path: CloudPath) -> bool:
     # TODO: this is two network requests, make it one
     for fut in asyncio.as_completed([isfile(path), isdir(path)]):
         if await fut:
@@ -571,7 +571,7 @@ async def _cloud_exists(path: CloudPath) -> int:
 
 
 @exists.register  # type: ignore
-async def _local_exists(path: LocalPath) -> int:
+async def _local_exists(path: LocalPath) -> bool:
     return os.path.exists(path)
 
 


### PR DESCRIPTION
Investigating https://github.com/python/mypy/pull/17487, I decided to check out an exemplar mypy_primer to see what all the fuss is about. Since it's so easy to fix this, and so obviously correct, I thought I'd do a PR about it while I'm here. The functions return bool and so should be annotated accordingly, not with int.