### PR TITLE
Respect proxy env vars

### DIFF
--- a/boostedblob/globals.py
+++ b/boostedblob/globals.py
@@ -223,7 +223,7 @@ def _create_session() -> aiohttp.ClientSession:
     # While the sleep suggested doesn't work, it does indicate that this is a problem for
     # aiohttp in general.
     connector = aiohttp.TCPConnector(limit=1024, ttl_dns_cache=60)
-    return aiohttp.ClientSession(connector=connector)
+    return aiohttp.ClientSession(connector=connector, trust_env=True)
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
aiohttp by default does not respect the proxy env vars: https://docs.aiohttp.org/en/stable/client_advanced.html#aiohttp-client-proxy-support

Go ahead and enable reading from the env vars, like the requests package and curl does