### PR TITLE
Set default user agent to something more useful

### DIFF
--- a/boostedblob/globals.py
+++ b/boostedblob/globals.py
@@ -122,7 +122,9 @@ class Config:
 
     chunk_size: int = 16 * MB
 
-    user_agent: str = f"boostedblob/{__version__} (Python/{platform.python_version()} aiohttp/{aiohttp.__version__})"
+    user_agent: str = (
+        f"boostedblob/{__version__} (Python/{platform.python_version()} aiohttp/{aiohttp.__version__})"
+    )
 
     connect_timeout: float = 20.0
     read_timeout: float = 60.0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -39,7 +39,10 @@ def test_xml():
 @bbb.ensure_session
 async def test_default_user_agent() -> None:
     session = bbb.globals.config.session
-    assert session.headers["User-Agent"] == bbb.globals.Config.__dataclass_fields__["user_agent"].default
+    assert (
+        session.headers["User-Agent"]
+        == bbb.globals.Config.__dataclass_fields__["user_agent"].default
+    )
 
 
 @pytest.mark.asyncio
@@ -51,4 +54,7 @@ async def test_user_agent_configurable() -> None:
         assert session.headers["User-Agent"] == custom
 
     session = bbb.globals.config.session
-    assert session.headers["User-Agent"] == bbb.globals.Config.__dataclass_fields__["user_agent"].default
+    assert (
+        session.headers["User-Agent"]
+        == bbb.globals.Config.__dataclass_fields__["user_agent"].default
+    )


### PR DESCRIPTION
It's helpful to have more information about clients in the server logs (e.g. in the blob diagnostic logs available from Azure). Make the User-Agent header configurable, but default it to (e.g.) `boostedblob/0.16.0 (Python/3.12.9 aiohttp/3.12.15)`