### PR TITLE
Handle broken pipes quietly in CLI

### DIFF
--- a/boostedblob/__main__.py
+++ b/boostedblob/__main__.py
@@ -1,12 +1,35 @@
 import os
+import signal
 import sys
 
 from boostedblob.cli import run_bbb
+
+BROKEN_PIPE_EXIT_CODE = 128 + int(getattr(signal, "SIGPIPE", 13))
+
+
+def silence_broken_pipe() -> None:
+    try:
+        stdout_fd = sys.stdout.fileno()
+    except (OSError, ValueError):
+        return
+
+    try:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        try:
+            # Avoid another BrokenPipeError when Python flushes stdout at shutdown.
+            os.dup2(devnull, stdout_fd)
+        finally:
+            os.close(devnull)
+    except OSError:
+        pass
 
 
 def main() -> None:
     try:
         run_bbb(sys.argv[1:])
+    except BrokenPipeError:
+        silence_broken_pipe()
+        sys.exit(BROKEN_PIPE_EXIT_CODE)
     except Exception:
         if os.environ.get("BBB_DEBUG") or os.environ.get("BBB_TRACEBACK"):
             raise

--- a/boostedblob/cli.py
+++ b/boostedblob/cli.py
@@ -803,6 +803,8 @@ def run_bbb(argv: list[str]) -> None:
         args = parse_options(argv)
         command = args.__dict__.pop("command")
         command(**args.__dict__)
+    except BrokenPipeError:
+        raise
     except Exception as e:
         print(f"ERROR: {type(e).__name__}: {e}", file=sys.stderr)
         raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,19 @@ def test_cli():
                 run_bbb(["lstree", remote_dir])
 
 
+def test_cat_ignores_broken_pipe_error_message(tmp_path, capsys):
+    path = tmp_path / "file"
+    path.write_bytes(b"contents")
+
+    output = io.StringIO()
+    output.buffer = MagicMock()  # type: ignore
+    output.buffer.write = MagicMock(side_effect=BrokenPipeError())
+    with contextlib.redirect_stdout(output), pytest.raises(BrokenPipeError):
+        boostedblob.cli.run_bbb(["cat", str(path)])
+
+    assert capsys.readouterr().err == ""
+
+
 def test_complete():
     with helpers.tmp_azure_dir() as azure_dir:
         helpers.create_file(azure_dir / "somefile")


### PR DESCRIPTION
## Summary

- avoid logging BrokenPipeError as a CLI error when stdout closes early
- silence Python stdout flush after a broken pipe and exit with SIGPIPE-style status
- add regression coverage for cat-style stdout writes

## Test plan

- pytest tests/test_cli.py::test_cat_ignores_broken_pipe_error_message -q
- ruff check boostedblob/cli.py boostedblob/__main__.py tests/test_cli.py
- git diff --check